### PR TITLE
修复cron的环境变量，使用绝对路径

### DIFF
--- a/dnspod_ddns_line.sh
+++ b/dnspod_ddns_line.sh
@@ -13,7 +13,7 @@ DEV="eth0"
 
 date
 IPREX='([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
-ipcmd="ip addr show";type ip >/dev/null 2>&1||ipcmd="ifconfig"
+ipcmd="/sbin/ip addr show";type ip >/dev/null 2>&1||ipcmd="/sbin/ifconfig"
 DEVIP=$($ipcmd $DEV|grep -Eo "$IPREX"|head -n1)
 echo "[DEV IP]:$DEVIP"
 dnscmd="nslookup";type nslookup >/dev/null 2>&1||dnscmd="ping -c1"


### PR DESCRIPTION
Debian中正常工作，CentOS在zsh中正常工作，但是crontab运行无法获取IP，排查后是环境变量的问题